### PR TITLE
Switch back to "latest" upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudbees/java-build-tools:1.0.0
+FROM cloudbees/java-build-tools
 
 USER root
 


### PR DESCRIPTION
After tagging the jnlp-slave-with-java-build-tools image, switch back to "latest" upstream image