### PR TITLE
Prepare version 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudbees/java-build-tools
+FROM cloudbees/java-build-tools:2.0.0
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cloudbees/java-build-tools:2.0.0
 
 USER root
 
-ARG JENKINS_REMOTING_VERSION=2.62.4
+ARG JENKINS_REMOTING_VERSION=3.4
 
 RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/$JENKINS_REMOTING_VERSION/remoting-$JENKINS_REMOTING_VERSION.jar \
   && chmod 755 /usr/share/jenkins \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See [README](https://hub.docker.com/r/cloudbees/java-build-tools/) for details o
 # Supported tags and respective `Dockerfile` links
 
 -   [`latest` (*latest/Dockerfile*)](https://github.com/cloudbees/jnlp-slave-with-java-build-tools-dockerfile/blob/master/Dockerfile)
+-   [`2.0.0` (*2.0.0/Dockerfile*)](https://github.com/cloudbees/jnlp-slave-with-java-build-tools-dockerfile/blob/2.0.0/Dockerfile)
 -   [`1.0.1` (*1.0.1/Dockerfile*)](https://github.com/cloudbees/jnlp-slave-with-java-build-tools-dockerfile/blob/1.0.1/Dockerfile)
 -   [`1.0.0` (*1.0.0/Dockerfile*)](https://github.com/cloudbees/jnlp-slave-with-java-build-tools-dockerfile/blob/1.0.0/Dockerfile)
 -   [`0.0.5.1` (*0.0.5.1/Dockerfile*)](https://github.com/cloudbees/jnlp-slave-with-java-build-tools-dockerfile/blob/0.0.5.1/Dockerfile)
@@ -22,6 +23,49 @@ This Docker image is intended to be used in conjunction with a Docker container 
 
 It can also be used "static" Jenkins slave connected to a Jenkins master declaring a JNLP slave but it would require to manually launch the Docker container.
 
+## Java
+
+Sample with the Jenkins [Pipeline Maven Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Maven+Plugin).
+
+```
+node ("jnlp-slave-with-java-build-tools") { // provided by the Kubernetes/Mesos/Amazon ECS Plugin
+
+    git "https://github.com/cloudbees-community/game-of-life"
+    withMaven(mavenSettingsConfig:'my-maven-settings') {
+       sh "mvn clean deploy"
+    }
+}
+```
+
+## Selenium
+
+The docker image enables Selenium tests bundling Firefox and starting selenium-server-standalone (listening on the default port 4444).
+
+### Selenium Sample with Java
+
+```
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+WebDriver webDriver = new RemoteWebDriver(DesiredCapabilities.firefox());
+webDriver.get("http://www.python.org");
+webDriver.getTitle();
+```
+
+### Selenium Sample with Python
+
+```
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+
+driver = webdriver.Remote(
+   command_executor='http://127.0.0.1:4444/wd/hub',
+   desired_capabilities=DesiredCapabilities.FIREFOX)
+
+driver.get('http://python.org')
+```
+
 # Running
 
 To run a Docker container
@@ -33,8 +77,66 @@ optional environment variables:
 * `JENKINS_URL`: url for the Jenkins server, can be used as a replacement to `-url` option, or to set alternate jenkins URL
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this slave host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 
-
 # Docker image details
+
+## Version latest
+
+-   OS: Ubuntu 16.04
+-   Common tools: openssh-client, unzip, wget, curl, git
+-   AWS CLI: aws-cli/1.11.41
+-   Azure CLI: 0.10.8
+-   Bower: 1.8.0
+-   Cloud Foundry CLI (latest) at `/usr/local/bin/cf`: 6.23.1
+-   Firefox at `/usr/bin/firefox`: 50.1.0
+-   Firefox Geckodriver at `/usr/bin/geckodriver`: v0.13.0
+-   gcc (latest): 5.4.0
+-   Grunt CLI: 1.2.0
+-   Gulp: 3.9.1
+-   Java: OpenJDK 8 (latest): 1.8.0_111
+-   JMeter (3.1) located in `/opt/jmeter/`
+-   Kubernetes CLI at `/usr/local/bin/kubectl`: 1.5.2
+-   Make (latest): 4.1
+-   Maven located in `/usr/share/maven/`: 3.3.9
+-   MySQL Client: 5.7.17
+-   Node.js at `/usr/bin/nodejs`: 6.9.4
+-   Npm at `/usr/bin/npm`: 3.10.10
+-   Open Shift V3 CLI at `/usr/local/bin/oc`: 1.3.0
+-   Python/2.7.12
+-   Selenium at `/opt/selenium/selenium-server-standalone.jar`: 2.53
+-   XVFB: 2:1.18.4
+
+-   Jenkins slave.jar (aka remoting.jar) at `/usr/share/jenkins/slave.jar`: 2.62.4
+
+## Version 2.0.0
+
+-   OS: Ubuntu 16.04
+-   Common tools: openssh-client, unzip, wget, curl, git
+-   AWS CLI: aws-cli/1.11.41
+-   Azure CLI: 0.10.8
+-   Bower: 1.8.0
+-   Cloud Foundry CLI (latest) at `/usr/local/bin/cf`: 6.23.1
+-   Firefox at `/usr/bin/firefox`: 50.1.0
+-   Firefox Geckodriver at `/usr/bin/geckodriver`: v0.13.0
+-   gcc (latest): 5.4.0
+-   Grunt CLI: 1.2.0
+-   Gulp: 3.9.1
+-   Java: OpenJDK 8 (latest): 1.8.0_111
+-   JMeter (3.1) located in `/opt/jmeter/`
+-   Kubernetes CLI at `/usr/local/bin/kubectl`: 1.5.2
+-   Make (latest): 4.1
+-   Maven located in `/usr/share/maven/`: 3.3.9
+-   MySQL Client: 5.7.17
+-   Node.js at `/usr/bin/nodejs`: 6.9.4
+-   Npm at `/usr/bin/npm`: 3.10.10
+-   Open Shift V3 CLI at `/usr/local/bin/oc`: 1.3.0
+-   Python/2.7.12
+-   Selenium at `/opt/selenium/selenium-server-standalone.jar`: 2.53
+-   XVFB: 2:1.18.4
+
+-   Jenkins slave.jar (aka remoting.jar): 2.62.4
+
+
+## Version 1.0.1
 
 -   OS: Ubuntu 15.04
 -   Build tools installed on [cloudbees/java-build-tools](https://hub.docker.com/r/cloudbees/java-build-tools/).

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ optional environment variables:
 -   Selenium at `/opt/selenium/selenium-server-standalone.jar`: 2.53
 -   XVFB: 2:1.18.4
 
--   Jenkins slave.jar (aka remoting.jar) at `/usr/share/jenkins/slave.jar`: 2.62.4
+-   Jenkins slave.jar (aka remoting.jar) at `/usr/share/jenkins/slave.jar`: 3.4
 
 ## Version 2.0.0
 
@@ -133,7 +133,7 @@ optional environment variables:
 -   Selenium at `/opt/selenium/selenium-server-standalone.jar`: 2.53
 -   XVFB: 2:1.18.4
 
--   Jenkins slave.jar (aka remoting.jar): 2.62.4
+-   Jenkins slave.jar (aka remoting.jar): 3.4
 
 
 ## Version 1.0.1


### PR DESCRIPTION
Prepare version 2.0.0 based on cloudbees/java-build-tools:2.0.0 which is a bump of Ubuntu from 15.04 to 16.04 + bump of selenium-standalone-server from 2.x to 3.x.